### PR TITLE
Add choices to positional argument in help sup-parser

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -109,7 +109,7 @@ class CommandLineParser:
         return 0
 
     def add_help_arguments(self, parser):
-        parser.add_argument('command', nargs='?')
+        parser.add_argument('command', nargs='?', choices=self.commands)
 
     def run_help_command(self, options):
         if options.command:


### PR DESCRIPTION
I add `self.commands` as `choices` in the help argument.  
_argparse_ save  a reference for `self.commands` - after all the _sub-parsers_ were defined the _help parser_ will have all the _sub-parsers_ in the `choices`  variable.

It also works with `-h/--h` .
```python
python meson.py help --help
```